### PR TITLE
fix: resize leak, hash2 coprimality, error code correctness, response…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ project(mjsonrpc
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic -Wshadow)
+endif()
+
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/output/lib)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/output)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is lightweight, has minimal dependencies, and can be integrated int
 - **Hash-based Method Indexing**: Fast method lookup using double hashing algorithm
 - **Batch Requests**: Support for JSON Array batch calls
 - **Customizable Memory Management**: User-defined malloc/free/strdup hooks
-- **Thread-Safe**: Thread-local storage for memory hooks
+- **Thread-Aware**: Thread-local storage for memory hooks enables per-thread customization
 - **POSIX Array Params**: Support for both object and array parameters
 - **Method Enumeration**: Query registered methods at runtime
 - **Error Logging**: Optional error logging hooks for debugging
@@ -256,9 +256,10 @@ const char *req = "{\"jsonrpc\":\"2.0\",\"method\":\"add\",\"params\":[1,2],\"id
 **A:** Use `mjrpc_enum_methods()` to get an array of method names:
 
 ```c
-cJSON *methods = mjrpc_enum_methods(handle, NULL, NULL);
-// methods is a JSON array of method name strings
-cJSON_Delete(methods);
+void print_method(const char *name, void *arg, void *user_data) {
+    printf("Method: %s\n", name);
+}
+mjrpc_enum_methods(handle, print_method, NULL);
 ```
 
 ### Q: What happens if the hash table needs to resize?

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,10 +15,15 @@ option(BUILD_STATIC_LIBRARY "Build static library" OFF)
 if(BUILD_STATIC_LIBRARY)
     add_library(${PROJECT_NAME}_static STATIC mjsonrpc.c)
     target_compile_definitions(${PROJECT_NAME}_static PRIVATE _DEFAULT_SOURCE)
+    target_include_directories(${PROJECT_NAME}_static
+        PUBLIC ${PROJECT_SOURCE_DIR}
+    )
+    target_link_libraries(${PROJECT_NAME}_static PUBLIC cJSON)
     set_target_properties(${PROJECT_NAME}_static PROPERTIES
         OUTPUT_NAME ${PROJECT_NAME}
         VERSION ${MJSONRPC_VERSION}
         SOVERSION ${MJSONRPC_VERSION_MAJOR}
+        PUBLIC_HEADER mjsonrpc.h
     )
 endif()
 
@@ -51,6 +56,7 @@ if(BUILD_STATIC_LIBRARY)
     install(TARGETS ${PROJECT_NAME}_static
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 endif()
 

--- a/src/mjsonrpc.c
+++ b/src/mjsonrpc.c
@@ -246,6 +246,10 @@ static cJSON *invoke_callback(const mjrpc_handle_t *handle,
     g_mjrpc_free(ctx.error_message);
     return err_resp;
   }
+  if (ctx.error_data) {
+    cJSON_Delete(ctx.error_data);
+  }
+  g_mjrpc_free(ctx.error_message);
   return mjrpc_response_ok(returned, id);
 }
 

--- a/src/mjsonrpc.c
+++ b/src/mjsonrpc.c
@@ -83,6 +83,28 @@ enum method_state { EMPTY, OCCUPIED, DELETED };
 #define HASH_MULTIPLIER2 17
 
 /**
+ * @brief Round a size_t up to the next power of two
+ * @param n Value to round up (0 returns 1)
+ * @return Next power of two >= n
+ * @internal
+ */
+static size_t next_power_of_2(size_t n) {
+  if (n == 0)
+    return 1;
+  n--;
+  n |= n >> 1;
+  n |= n >> 2;
+  n |= n >> 4;
+  n |= n >> 8;
+  n |= n >> 16;
+#if SIZE_MAX > 0xFFFFFFFF
+  n |= n >> 32;
+#endif
+  n++;
+  return n;
+}
+
+/**
  * @brief Compute hash value for a string key using djb2 algorithm
  * @param key String key to hash (must not be NULL for valid hash)
  * @param capacity Hash table capacity
@@ -104,11 +126,12 @@ static size_t hash(const char *key, size_t capacity) {
 /**
  * @brief Compute second hash value for double hashing
  * @param key String key to hash
- * @param capacity Hash table capacity
- * @return Second hash value for probe step size
+ * @param capacity Hash table capacity (must be a power of two)
+ * @return Second hash value for probe step size in range [1, capacity-1]
  *
- * @note Returns a prime-based hash for use as step size in double hashing
- *       Ensures step size is relatively prime to table capacity
+ * @note The returned step is forced to be odd. An odd step is always
+ *       coprime with a power-of-two capacity, guaranteeing the probe
+ *       sequence visits every slot before repeating.
  */
 static size_t hash2(const char *key, size_t capacity) {
   if (key == NULL || capacity <= 1)
@@ -117,10 +140,15 @@ static size_t hash2(const char *key, size_t capacity) {
   while (*key) {
     hash_value = (hash_value * HASH_MULTIPLIER2) + (unsigned char)(*key++);
   }
-  /* Return odd value in range [1, capacity-1] to ensure valid probe step.
-   * Odd step guarantees coprimality with power-of-2 capacity. */
+  /* Step in [1, capacity-1]; force odd so it is coprime with any
+   * power-of-two capacity.  With power-of-two cap, this always yields
+   * step <= capacity - 1. */
   size_t step = 1 + (hash_value % (capacity - 1));
-  return (step % 2 == 0) ? step + 1 : step;
+  if (step % 2 == 0)
+    step++;  /* make odd */
+  if (step >= capacity)
+    step = 1;  /* defensive cap */
+  return step;
 }
 
 static int resize(mjrpc_handle_t *handle) {
@@ -414,6 +442,7 @@ mjrpc_handle_t *mjrpc_create_handle(size_t initial_capacity) {
   init_memory_hooks_if_needed();
   if (initial_capacity == 0)
     initial_capacity = DEFAULT_INITIAL_CAPACITY;
+  initial_capacity = next_power_of_2(initial_capacity);
   mjrpc_handle_t *handle = g_mjrpc_malloc(sizeof(mjrpc_handle_t));
   if (handle == NULL)
     return NULL;

--- a/src/mjsonrpc.c
+++ b/src/mjsonrpc.c
@@ -116,7 +116,7 @@ static size_t next_power_of_2(size_t n) {
 static size_t hash(const char *key, size_t capacity) {
   if (key == NULL)
     return 0;
-  size_t hash_value = 5381;  /* Initial hash value (prime) */
+  size_t hash_value = 5381; /* Initial hash value (prime) */
   while (*key) {
     hash_value = ((hash_value << 5) + hash_value) + (unsigned char)(*key++);
   }
@@ -135,7 +135,7 @@ static size_t hash(const char *key, size_t capacity) {
  */
 static size_t hash2(const char *key, size_t capacity) {
   if (key == NULL || capacity <= 1)
-    return 1;  /* Minimum step size */
+    return 1; /* Minimum step size */
   size_t hash_value = 0;
   while (*key) {
     hash_value = (hash_value * HASH_MULTIPLIER2) + (unsigned char)(*key++);
@@ -145,9 +145,9 @@ static size_t hash2(const char *key, size_t capacity) {
    * step <= capacity - 1. */
   size_t step = 1 + (hash_value % (capacity - 1));
   if (step % 2 == 0)
-    step++;  /* make odd */
+    step++; /* make odd */
   if (step >= capacity)
-    step = 1;  /* defensive cap */
+    step = 1; /* defensive cap */
   return step;
 }
 
@@ -169,7 +169,8 @@ static int resize(mjrpc_handle_t *handle) {
   if (handle->methods == NULL) {
     handle->capacity = old_capacity;
     handle->methods = old_methods;
-    log_error("Hash table resize memory allocation failed", MJRPC_RET_ERROR_MEM_ALLOC_FAILED);
+    log_error("Hash table resize memory allocation failed",
+              MJRPC_RET_ERROR_MEM_ALLOC_FAILED);
     return MJRPC_RET_ERROR_MEM_ALLOC_FAILED;
   }
   memset(handle->methods, 0, handle->capacity * sizeof(struct mjrpc_method));
@@ -200,7 +201,8 @@ static int resize(mjrpc_handle_t *handle) {
   g_mjrpc_free(old_methods);
 
   if (rehash_failures > 0) {
-    log_error("Hash table resize completed with method failures", rehash_failures);
+    log_error("Hash table resize completed with method failures",
+              rehash_failures);
   }
   return MJRPC_RET_OK;
 }
@@ -225,11 +227,12 @@ static bool method_get(const mjrpc_handle_t *handle, const char *key,
     }
     probe_count++;
     if (probe_count >= handle->capacity) {
-      break;  /* Table is full, key not found */
+      break; /* Table is full, key not found */
     }
     /* Double hashing: index = (hash1 + i * hash2) % capacity */
     if (step_size == 0) {
-      step_size = hash2(key, handle->capacity);  /* Compute step size on first probe */
+      step_size =
+          hash2(key, handle->capacity); /* Compute step size on first probe */
     }
     index = (index + step_size) % handle->capacity;
   }
@@ -258,7 +261,8 @@ static cJSON *invoke_callback(const mjrpc_handle_t *handle,
   returned = func(&ctx, params, id);
   if (ctx.error_code) {
     cJSON_Delete(returned);
-    cJSON *err_resp = mjrpc_response_error(ctx.error_code, ctx.error_message, id);
+    cJSON *err_resp =
+        mjrpc_response_error(ctx.error_code, ctx.error_message, id);
     if (err_resp && ctx.error_data) {
       cJSON *error = cJSON_GetObjectItem(err_resp, "error");
       if (error) {
@@ -308,8 +312,7 @@ static cJSON *rpc_handle_obj_req(const mjrpc_handle_t *handle,
         strcmp("2.0", version->valuestring) != 0)
       return mjrpc_response_error(
           JSON_RPC_CODE_INVALID_REQUEST,
-          "Invalid request received: JSONRPC version error.",
-          id_copy);
+          "Invalid request received: JSONRPC version error.", id_copy);
 
     const cJSON *method = cJSON_GetObjectItem(request, "method");
     if (method != NULL && method->type == cJSON_String) {
@@ -324,16 +327,14 @@ static cJSON *rpc_handle_obj_req(const mjrpc_handle_t *handle,
       return invoke_callback(handle, method->valuestring, params, id_copy,
                              actual_params_type);
     }
-    return mjrpc_response_error(
-        JSON_RPC_CODE_INVALID_REQUEST,
-        "Invalid request received: No 'method' member.",
-        id_copy);
+    return mjrpc_response_error(JSON_RPC_CODE_INVALID_REQUEST,
+                                "Invalid request received: No 'method' member.",
+                                id_copy);
   }
   // Invalid id type
   return mjrpc_response_error(
       JSON_RPC_CODE_INVALID_REQUEST,
-      "Invalid request received: 'id' member type error.",
-      cJSON_CreateNull());
+      "Invalid request received: 'id' member type error.", cJSON_CreateNull());
 }
 
 static cJSON *rpc_handle_ary_req(const mjrpc_handle_t *handle,
@@ -507,24 +508,28 @@ int mjrpc_add_method(mjrpc_handle_t *handle, mjrpc_func function_pointer,
     }
     probe_count++;
     if (probe_count >= handle->capacity) {
-      break;  /* Table is full, should not happen with resize */
+      break; /* Table is full, should not happen with resize */
     }
     /* Double hashing: index = (hash1 + i * hash2) % capacity */
     if (step_size == 0) {
-      step_size = hash2(method_name, handle->capacity);  /* Compute step size on first probe */
+      step_size = hash2(
+          method_name, handle->capacity); /* Compute step size on first probe */
     }
     index = (index + step_size) % handle->capacity;
   }
 
-  /* Check if hash table is full (shouldn't happen with resize, but safety check) */
+  /* Check if hash table is full (shouldn't happen with resize, but safety
+   * check) */
   if (probe_count >= handle->capacity) {
-    log_error("Hash table full during add_method (should not happen)", MJRPC_RET_ERROR_MEM_ALLOC_FAILED);
+    log_error("Hash table full during add_method (should not happen)",
+              MJRPC_RET_ERROR_MEM_ALLOC_FAILED);
     return MJRPC_RET_ERROR_MEM_ALLOC_FAILED;
   }
 
   handle->methods[index].name = g_mjrpc_strdup(method_name);
   if (handle->methods[index].name == NULL) {
-    log_error("strdup failed during add_method", MJRPC_RET_ERROR_MEM_ALLOC_FAILED);
+    log_error("strdup failed during add_method",
+              MJRPC_RET_ERROR_MEM_ALLOC_FAILED);
     return MJRPC_RET_ERROR_MEM_ALLOC_FAILED;
   }
   handle->methods[index].func = function_pointer;
@@ -561,11 +566,12 @@ int mjrpc_del_method(mjrpc_handle_t *handle, const char *name) {
     }
     probe_count++;
     if (probe_count >= handle->capacity) {
-      break;  /* Table is full, key not found */
+      break; /* Table is full, key not found */
     }
     /* Double hashing: index = (hash1 + i * hash2) % capacity */
     if (step_size == 0) {
-      step_size = hash2(name, handle->capacity);  /* Compute step size on first probe */
+      step_size =
+          hash2(name, handle->capacity); /* Compute step size on first probe */
     }
     index = (index + step_size) % handle->capacity;
   }
@@ -654,8 +660,7 @@ cJSON *mjrpc_process_cjson(const mjrpc_handle_t *handle,
       ret = MJRPC_RET_ERROR_EMPTY_REQUEST;
       cjson_return = mjrpc_response_error(
           JSON_RPC_CODE_INVALID_REQUEST,
-          "Invalid request received: Empty JSON array.",
-          cJSON_CreateNull());
+          "Invalid request received: Empty JSON array.", cJSON_CreateNull());
     } else {
       cjson_return = rpc_handle_ary_req(handle, request_cjson, array_size);
       if (cjson_return)
@@ -668,8 +673,7 @@ cJSON *mjrpc_process_cjson(const mjrpc_handle_t *handle,
       ret = MJRPC_RET_ERROR_EMPTY_REQUEST;
       cjson_return = mjrpc_response_error(
           JSON_RPC_CODE_INVALID_REQUEST,
-          "Invalid request received: Empty JSON object.",
-          cJSON_CreateNull());
+          "Invalid request received: Empty JSON object.", cJSON_CreateNull());
     } else {
       cjson_return = rpc_handle_obj_req(handle, request_cjson);
       if (cjson_return)

--- a/src/mjsonrpc.c
+++ b/src/mjsonrpc.c
@@ -27,7 +27,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 
 /*--- memory management hooks ---*/
 
@@ -112,14 +111,16 @@ static size_t hash(const char *key, size_t capacity) {
  *       Ensures step size is relatively prime to table capacity
  */
 static size_t hash2(const char *key, size_t capacity) {
-  if (key == NULL)
+  if (key == NULL || capacity <= 1)
     return 1;  /* Minimum step size */
   size_t hash_value = 0;
   while (*key) {
     hash_value = (hash_value * HASH_MULTIPLIER2) + (unsigned char)(*key++);
   }
-  /* Return value in range [1, capacity-1] to ensure valid probe step */
-  return 1 + (hash_value % (capacity - 1));
+  /* Return odd value in range [1, capacity-1] to ensure valid probe step.
+   * Odd step guarantees coprimality with power-of-2 capacity. */
+  size_t step = 1 + (hash_value % (capacity - 1));
+  return (step % 2 == 0) ? step + 1 : step;
 }
 
 static int resize(mjrpc_handle_t *handle) {
@@ -163,7 +164,9 @@ static int resize(mjrpc_handle_t *handle) {
         /* Continue with remaining methods instead of aborting */
         continue;
       }
-      /* name_copy and arg_copy now owned by new entry, don't free them */
+      /* mjrpc_add_method strdups the name, so free our copy.
+       * arg_copy is now owned by the new entry, do not free it. */
+      g_mjrpc_free(name_copy);
     }
   }
   g_mjrpc_free(old_methods);
@@ -217,17 +220,29 @@ static cJSON *invoke_callback(const mjrpc_handle_t *handle,
   mjrpc_func_ctx_t ctx = {0};
   ctx.error_code = 0;
   ctx.error_message = NULL;
+  ctx.error_data = NULL;
   ctx.params_type = params_type;
-  if (!method_get((mjrpc_handle_t *)handle, method_name, &func, &arg) ||
-      !func) {
+  if (!method_get(handle, method_name, &func, &arg) || !func) {
     return mjrpc_response_error(JSON_RPC_CODE_METHOD_NOT_FOUND,
-                                g_mjrpc_strdup("Method not found."), id);
+                                "Method not found.", id);
   }
   ctx.data = arg;
   returned = func(&ctx, params, id);
   if (ctx.error_code) {
     cJSON_Delete(returned);
-    return mjrpc_response_error(ctx.error_code, ctx.error_message, id);
+    cJSON *err_resp = mjrpc_response_error(ctx.error_code, ctx.error_message, id);
+    if (err_resp && ctx.error_data) {
+      cJSON *error = cJSON_GetObjectItem(err_resp, "error");
+      if (error) {
+        cJSON_AddItemToObject(error, "data", ctx.error_data);
+      } else {
+        cJSON_Delete(ctx.error_data);
+      }
+    } else if (ctx.error_data) {
+      cJSON_Delete(ctx.error_data);
+    }
+    g_mjrpc_free(ctx.error_message);
+    return err_resp;
   }
   return mjrpc_response_ok(returned, id);
 }
@@ -259,7 +274,7 @@ static cJSON *rpc_handle_obj_req(const mjrpc_handle_t *handle,
         strcmp("2.0", version->valuestring) != 0)
       return mjrpc_response_error(
           JSON_RPC_CODE_INVALID_REQUEST,
-          g_mjrpc_strdup("Invalid request received: JSONRPC version error."),
+          "Invalid request received: JSONRPC version error.",
           id_copy);
 
     const cJSON *method = cJSON_GetObjectItem(request, "method");
@@ -277,13 +292,13 @@ static cJSON *rpc_handle_obj_req(const mjrpc_handle_t *handle,
     }
     return mjrpc_response_error(
         JSON_RPC_CODE_INVALID_REQUEST,
-        g_mjrpc_strdup("Invalid request received: No 'method' member."),
+        "Invalid request received: No 'method' member.",
         id_copy);
   }
   // Invalid id type
   return mjrpc_response_error(
       JSON_RPC_CODE_INVALID_REQUEST,
-      g_mjrpc_strdup("Invalid request received: 'id' member type error."),
+      "Invalid request received: 'id' member type error.",
       cJSON_CreateNull());
 }
 
@@ -370,9 +385,6 @@ cJSON *mjrpc_response_error(int code, const char *message, cJSON *id) {
   cJSON *result_root = cJSON_CreateObject();
   cJSON *error_root = cJSON_CreateObject();
   if (result_root == NULL || error_root == NULL || id == NULL) {
-    if (message)
-      g_mjrpc_free(
-          (void *)message); // Free the message string if it was allocated
     cJSON_Delete(id);
     cJSON_Delete(error_root);
     cJSON_Delete(result_root);
@@ -382,8 +394,6 @@ cJSON *mjrpc_response_error(int code, const char *message, cJSON *id) {
   cJSON_AddNumberToObject(error_root, "code", code);
   if (message) {
     cJSON_AddStringToObject(error_root, "message", message);
-    g_mjrpc_free(
-        (void *)message); // Free the message string after adding to JSON
   } else
     cJSON_AddStringToObject(error_root, "message", "No message here.");
 
@@ -560,8 +570,7 @@ char *mjrpc_process_str(const mjrpc_handle_t *handle, const char *request_str,
     }
     cJSON *error_resp = mjrpc_response_error(
         JSON_RPC_CODE_PARSE_ERROR,
-        g_mjrpc_strdup(
-            "Invalid request received: Not a JSON formatted request."),
+        "Invalid request received: Not a JSON formatted request.",
         cJSON_CreateNull());
     if (error_resp) {
       char *response_str = cJSON_PrintUnformatted(error_resp);
@@ -599,8 +608,7 @@ cJSON *mjrpc_process_cjson(const mjrpc_handle_t *handle,
       *ret_code = ret;
     return mjrpc_response_error(
         JSON_RPC_CODE_PARSE_ERROR,
-        g_mjrpc_strdup(
-            "Invalid request received: Not a JSON formatted request."),
+        "Invalid request received: Not a JSON formatted request.",
         cJSON_CreateNull());
   }
 
@@ -610,8 +618,8 @@ cJSON *mjrpc_process_cjson(const mjrpc_handle_t *handle,
     if (array_size <= 0) {
       ret = MJRPC_RET_ERROR_EMPTY_REQUEST;
       cjson_return = mjrpc_response_error(
-          JSON_RPC_CODE_PARSE_ERROR,
-          g_mjrpc_strdup("Invalid request received: Empty JSON array."),
+          JSON_RPC_CODE_INVALID_REQUEST,
+          "Invalid request received: Empty JSON array.",
           cJSON_CreateNull());
     } else {
       cjson_return = rpc_handle_ary_req(handle, request_cjson, array_size);
@@ -621,13 +629,11 @@ cJSON *mjrpc_process_cjson(const mjrpc_handle_t *handle,
         ret = MJRPC_RET_OK_NOTIFICATION;
     }
   } else if (request_cjson->type == cJSON_Object) {
-    // Check if the object is empty by checking if it has any children
-    const int obj_size = (request_cjson->child != NULL) ? 1 : 0;
-    if (obj_size <= 0) {
+    if (request_cjson->child == NULL) {
       ret = MJRPC_RET_ERROR_EMPTY_REQUEST;
       cjson_return = mjrpc_response_error(
-          JSON_RPC_CODE_PARSE_ERROR,
-          g_mjrpc_strdup("Invalid request received: Empty JSON object."),
+          JSON_RPC_CODE_INVALID_REQUEST,
+          "Invalid request received: Empty JSON object.",
           cJSON_CreateNull());
     } else {
       cjson_return = rpc_handle_obj_req(handle, request_cjson);
@@ -638,8 +644,8 @@ cJSON *mjrpc_process_cjson(const mjrpc_handle_t *handle,
     }
   } else {
     cjson_return = mjrpc_response_error(
-        JSON_RPC_CODE_PARSE_ERROR,
-        g_mjrpc_strdup("Invalid request received: Not a JSON object or array."),
+        JSON_RPC_CODE_INVALID_REQUEST,
+        "Invalid request received: Not a JSON object or array.",
         cJSON_CreateNull());
     ret = MJRPC_RET_ERROR_NOT_OBJ_ARY;
   }

--- a/src/mjsonrpc.c
+++ b/src/mjsonrpc.c
@@ -234,7 +234,9 @@ static cJSON *invoke_callback(const mjrpc_handle_t *handle,
     if (err_resp && ctx.error_data) {
       cJSON *error = cJSON_GetObjectItem(err_resp, "error");
       if (error) {
-        cJSON_AddItemToObject(error, "data", ctx.error_data);
+        if (!cJSON_AddItemToObject(error, "data", ctx.error_data)) {
+          cJSON_Delete(ctx.error_data);
+        }
       } else {
         cJSON_Delete(ctx.error_data);
       }

--- a/src/mjsonrpc.h
+++ b/src/mjsonrpc.h
@@ -469,6 +469,7 @@ cJSON *mjrpc_response_error(int code, const char *message, cJSON *id);
  * @retval NULL If memory allocation failed
  *
  * @note If initial_capacity is 0, a default capacity will be used
+ * @note The actual capacity is rounded up to the nearest power of two
  * @note The handle must be destroyed with mjrpc_destroy_handle() to prevent
  * memory leaks
  *

--- a/src/mjsonrpc.h
+++ b/src/mjsonrpc.h
@@ -129,6 +129,10 @@ typedef struct {
    * automatically) */
   char *error_message;
 
+  /** @brief Optional structured error data to be included in the error response
+   * (will be freed automatically, can be NULL) */
+  cJSON *error_data;
+
   /** @brief Parameter type: 0=object, 1=array, 2=no params */
   int params_type;
 } mjrpc_func_ctx_t;
@@ -427,15 +431,17 @@ cJSON *mjrpc_response_ok(cJSON *result, cJSON *id);
  * @param id Client request ID (will be owned by response)
  *
  * @return cJSON pointer containing the error response (caller must delete)
- * @retval NULL If an error occurred (message and id will be released)
+ * @retval NULL If an error occurred (id will be released)
  *
  * @note If message is NULL, a default message will be used
+ * @note The message string is copied by cJSON; caller retains ownership.
  *
  * @par Example:
  * @code
  * cJSON *id = cJSON_CreateNumber(1);
- * cJSON *response = mjrpc_response_error(JSON_RPC_CODE_INVALID_PARAMS, "Invalid
- * parameters", id); if (response) {
+ * cJSON *response = mjrpc_response_error(JSON_RPC_CODE_INVALID_PARAMS,
+ *                                        "Invalid parameters", id);
+ * if (response) {
  *     // Send error response...
  *     cJSON_Delete(response);
  * }
@@ -531,6 +537,7 @@ int mjrpc_destroy_handle(mjrpc_handle_t *handle);
  * @retval MJRPC_RET_ERROR_MEM_ALLOC_FAILED If memory allocation failed
  *
  * @note If a method with the same name already exists, it will be replaced
+ * @note The old arg will be freed automatically on replacement
  * @note The method_name will be copied internally
  *
  * @par Example:
@@ -560,6 +567,7 @@ int mjrpc_add_method(mjrpc_handle_t *handle, mjrpc_func function_pointer,
  *
  * @return Error code from enum mjrpc_error_return
  * @retval MJRPC_RET_OK If successful
+ * @retval MJRPC_RET_ERROR_HANDLE_NOT_INITIALIZED If handle is NULL
  * @retval MJRPC_RET_ERROR_INVALID_PARAM If method_name is NULL
  * @retval MJRPC_RET_ERROR_NOT_FOUND If method was not found
  *

--- a/src/mjsonrpc.pc.in
+++ b/src/mjsonrpc.pc.in
@@ -6,6 +6,5 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 Name: mjsonrpc
 Description: A lightweight JSON-RPC 2.0 message parser and generator based on cJSON
 Version: @MJSONRPC_VERSION@
-Requires: cjson
 Libs: -L${libdir} -lmjsonrpc
 Cflags: -I${includedir}

--- a/src/mjsonrpc.pc.in
+++ b/src/mjsonrpc.pc.in
@@ -6,6 +6,6 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 Name: mjsonrpc
 Description: A lightweight JSON-RPC 2.0 message parser and generator based on cJSON
 Version: @MJSONRPC_VERSION@
-Requires:
+Requires: cjson
 Libs: -L${libdir} -lmjsonrpc
 Cflags: -I${includedir}

--- a/test/arry_test.c
+++ b/test/arry_test.c
@@ -97,7 +97,7 @@ void test_batch_request_empty_array(void)
     TEST_ASSERT_NOT_NULL(error);
     cJSON* code_item = cJSON_GetObjectItem(error, "code");
     TEST_ASSERT_EQUAL_INT(MJRPC_RET_ERROR_EMPTY_REQUEST, code);
-    TEST_ASSERT_EQUAL_INT(JSON_RPC_CODE_PARSE_ERROR, code_item->valueint);
+    TEST_ASSERT_EQUAL_INT(JSON_RPC_CODE_INVALID_REQUEST, code_item->valueint);
     cJSON_Delete(resp);
     mjrpc_destroy_handle(h);
 }

--- a/test/regression_test.c
+++ b/test/regression_test.c
@@ -95,6 +95,28 @@ static cJSON* ok_func(mjrpc_func_ctx_t* ctx, cJSON* params, cJSON* id)
     return cJSON_CreateString("ok");
 }
 
+/* Enumeration counter */
+static int enum_count = 0;
+static void enum_callback(const char* name, void* arg, void* user_data)
+{
+    (void)arg;
+    (void)user_data;
+    (void)name;
+    enum_count++;
+}
+
+/* Callback that sets error_data */
+static cJSON* error_with_data_func(mjrpc_func_ctx_t* ctx, cJSON* params, cJSON* id)
+{
+    (void)params;
+    (void)id;
+    ctx->error_code = -32001;
+    ctx->error_message = strdup("validation failed");
+    ctx->error_data = cJSON_CreateObject();
+    cJSON_AddStringToObject(ctx->error_data, "field", "age");
+    return NULL;
+}
+
 /* ================================================================== */
 /*  BUG-3 : Batch request where ALL items are notifications           */
 /*          Before fix, return_json_array was leaked.                  */
@@ -353,6 +375,70 @@ void test_hash1_add_delete_readd(void)
 }
 
 /* ================================================================== */
+/*  enum_methods coverage                                             */
+/* ================================================================== */
+
+void test_enum_methods_basic(void)
+{
+    mjrpc_handle_t* h = mjrpc_create_handle(8);
+    TEST_ASSERT_NOT_NULL(h);
+    mjrpc_add_method(h, ok_func, "alpha", NULL);
+    mjrpc_add_method(h, ok_func, "beta", NULL);
+
+    enum_count = 0;
+    int ret = mjrpc_enum_methods(h, enum_callback, NULL);
+    TEST_ASSERT_EQUAL_INT(MJRPC_RET_OK, ret);
+    TEST_ASSERT_EQUAL_INT(2, enum_count);
+
+    mjrpc_destroy_handle(h);
+}
+
+void test_enum_methods_null_handle(void)
+{
+    int ret = mjrpc_enum_methods(NULL, enum_callback, NULL);
+    TEST_ASSERT_EQUAL_INT(MJRPC_RET_ERROR_HANDLE_NOT_INITIALIZED, ret);
+}
+
+void test_enum_methods_null_callback(void)
+{
+    mjrpc_handle_t* h = mjrpc_create_handle(8);
+    int ret = mjrpc_enum_methods(h, NULL, NULL);
+    TEST_ASSERT_EQUAL_INT(MJRPC_RET_ERROR_INVALID_PARAM, ret);
+    mjrpc_destroy_handle(h);
+}
+
+/* ================================================================== */
+/*  error_data support                                                */
+/* ================================================================== */
+
+void test_error_data_in_response(void)
+{
+    mjrpc_handle_t* h = mjrpc_create_handle(8);
+    TEST_ASSERT_NOT_NULL(h);
+    mjrpc_add_method(h, error_with_data_func, "validate", NULL);
+
+    cJSON* id = cJSON_CreateNumber(1);
+    cJSON* req = mjrpc_request_cjson("validate", NULL, id);
+    int code = -1;
+    cJSON* resp = mjrpc_process_cjson(h, req, &code);
+    TEST_ASSERT_NOT_NULL(resp);
+
+    cJSON* error = cJSON_GetObjectItem(resp, "error");
+    TEST_ASSERT_NOT_NULL(error);
+
+    cJSON* data = cJSON_GetObjectItem(error, "data");
+    TEST_ASSERT_NOT_NULL(data);
+
+    cJSON* field = cJSON_GetObjectItem(data, "field");
+    TEST_ASSERT_NOT_NULL(field);
+    TEST_ASSERT_EQUAL_STRING("age", field->valuestring);
+
+    cJSON_Delete(req);
+    cJSON_Delete(resp);
+    mjrpc_destroy_handle(h);
+}
+
+/* ================================================================== */
 /*  main                                                              */
 /* ================================================================== */
 
@@ -378,6 +464,12 @@ int main(void)
     /* HASH-1 */
     RUN_TEST(test_hash1_probe_loop_terminates);
     RUN_TEST(test_hash1_add_delete_readd);
+
+    /* API coverage */
+    RUN_TEST(test_enum_methods_basic);
+    RUN_TEST(test_enum_methods_null_handle);
+    RUN_TEST(test_enum_methods_null_callback);
+    RUN_TEST(test_error_data_in_response);
 
     return UNITY_END();
 }


### PR DESCRIPTION
…_error ownership

Fixes:
- resize() now frees old method name strings after successful rehash (mjrpc_add_method strdups them, so the old copies were leaked)
- hash2() now forces odd step size, guaranteeing coprimality with power-of-2 capacity; added capacity <= 1 guard
- Empty array/object/non-object top-level requests now return -32600 Invalid Request instead of -32700 Parse Error per spec
- mjrpc_response_error no longer frees its message param; cJSON copies it internally. Removed internal g_mjrpc_strdup wrappers. Docs and example updated to reflect caller-retains-ownership contract.
- invoke_callback now explicitly frees ctx.error_message after use
- Static library build fixed (missing include/link targets)

Improvements:
- Added compiler warning flags (-Wall -Wextra -Wpedantic -Wshadow)
- Added error_data field to mjrpc_func_ctx_t for structured errors
- Added mjrpc_enum_methods tests (basic, null handle, null callback)
- Added error_data response test
- Fixed README enum_methods example (was non-compiling)
- Changed "Thread-Safe" claim to "Thread-Aware" in README
- Added Requires: cjson to pkg-config file
- Removed unused #include <stdio.h> and unnecessary const cast